### PR TITLE
Add integer and enum management to serialisable class.

### DIFF
--- a/serialisable.hpp
+++ b/serialisable.hpp
@@ -409,7 +409,7 @@ protected:
 	typename std::enable_if<std::is_enum<T>::value, bool>::type
 		synch(const std::string& key, T& value) {
 		if (preferencesSaving_) {
-			preferencesJson_->getObject()[key] = std::make_shared<JSONint>(int(value));
+			preferencesJson_->getObject()[key] = std::make_shared<JSONint>(std::underlying_type_t<T>(value));
 		}
 		else {
 			auto found = preferencesJson_->getObject().find(key);

--- a/serialisable_test.cpp
+++ b/serialisable_test.cpp
@@ -1,6 +1,11 @@
 #include <iostream>
 #include "serialisable.hpp"
 
+enum DocumentType {
+	BOOK = 1,
+	ESSAY
+};
+
 struct Chapter : public Serialisable {
 	std::string contents = "";
 	std::string author = "Anonymous";
@@ -14,7 +19,11 @@ struct Chapter : public Serialisable {
 struct Preferences : public Serialisable {
 	std::string lastFolder = "";
 	unsigned int lastOpen = 0;
+	int daysUntilPublication = -5;
+	uint64_t maxFilesAllowed = UINT64_MAX;
+	double relativeValue = 0.45;
 	bool privileged = false;
+	DocumentType documentType = BOOK;
 	Chapter info;
 	std::vector<Chapter> chapters;
 	std::vector<std::shared_ptr<Chapter>> footnotes;
@@ -24,7 +33,11 @@ struct Preferences : public Serialisable {
 	virtual void serialisation() {
 		synch("last_folder", lastFolder);
 		synch("last_open", lastOpen);
+		synch("days_until_publication", daysUntilPublication);
+		synch("max_files_allowed", maxFilesAllowed);
+		synch("relative_value", relativeValue);
 		synch("privileged", privileged);
+		synch("document_type", documentType);
 		synch("info", info);
 		synch("chapters", chapters);
 		synch("footnotes", footnotes);
@@ -36,12 +49,13 @@ struct Preferences : public Serialisable {
 int main() {
 	Serialisable::JSONobject testJson;
 	testJson.getObject()["file"] = std::make_shared<Serialisable::JSONstring>("test.json");
-	testJson.getObject()["number"] = std::make_shared<Serialisable::JSONdouble>(9);
+	testJson.getObject()["number"] = std::make_shared<Serialisable::JSONint>(9);
+	testJson.getObject()["float_number"] = std::make_shared<Serialisable::JSONdouble>(9);
 	testJson.getObject()["makes_sense"] = std::make_shared<Serialisable::JSONbool>(false);
 	std::shared_ptr<Serialisable::JSONarray> array = std::make_shared<Serialisable::JSONarray>();
 	for (int i = 0; i < 3; i++) {
 		std::shared_ptr<Serialisable::JSONobject> obj = std::make_shared<Serialisable::JSONobject>();
-		obj->getObject()["index"] = std::make_shared<Serialisable::JSONdouble>(i);
+		obj->getObject()["index"] = std::make_shared<Serialisable::JSONint>(i);
 		std::shared_ptr<Serialisable::JSONobject> obj2 = std::make_shared<Serialisable::JSONobject>();
 		obj->getObject()["contents"] = obj2;
 		obj2->getObject()["empty"] = std::make_shared<Serialisable::JSONobject>();
@@ -52,7 +66,8 @@ int main() {
 
 	std::shared_ptr<Serialisable::JSON> testReadJson = Serialisable::parseJSON("test.json");
 	testReadJson->getObject()["makes_sense"]->getBool() = true;
-	testReadJson->getObject()["number"]->getDouble() = 42;
+	testReadJson->getObject()["number"]->getInt() = 42;
+	testReadJson->getObject()["float_number"]->getDouble() = 4.9;
 	testReadJson->writeToFile("test-reread.json");
 
 	Preferences prefs;
@@ -60,6 +75,7 @@ int main() {
 	prefs.footnotes.push_back(std::make_shared<Chapter>());
 	prefs.footnotes.back()->contents = "There will be a lot of footnotes";
 	prefs.footnotes.back()->author = "Dugi";
+	prefs.documentType = ESSAY;
 	prefs.save("prefs.json");
 
 	return 0;


### PR DESCRIPTION
`enum`s are serialised and deserialised as integers.

Update tests to show that enums, ints and large ints are correctly handled, and that previous double values retain their expected behaviour.